### PR TITLE
fix: avoid hardcoded path of `ll-cli` in application desktop file

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -64,6 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace misc/share/applications/linyaps.desktop \
       --replace-fail "/usr/bin/ll-cli" "$out/bin/ll-cli"
+
+    # Don't use hardcoded paths in the application's desktop file, as it would become invalid when the old linyaps gets removed.
+    substituteInPlace libs/linglong/src/linglong/repo/ostree_repo.cpp \
+      --replace-fail 'LINGLONG_CLIENT_PATH' 'LINGLONG_CLIENT_NAME'
   '';
 
   buildInputs = [


### PR DESCRIPTION
Use `ll-cli` instead of `$out/bin/ll-cli` in application's desktop file, because the latter would become invalid when old version of linyaps gets removed.